### PR TITLE
Update compodoc + allow links to raw compodoc documentation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,10 +13,6 @@ jobs:
         name: Linting
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/cache@v1
-              with:
-                  path: ./node_modules
-                  key: ${{github.sha}}-node_modules
             - run: |
                   npm ci
                   npm run lint
@@ -43,6 +39,10 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/cache@v1
               with:
+                path: ./dist/plain-js-live-docs
+                key: ${{github.sha}}-plain-js-live-docs
+            - uses: actions/cache@v1
+              with:
                 path: ./dist/ng-live-docs
                 key: ${{github.sha}}-ng-live-docs
             - run: |
@@ -57,8 +57,12 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/cache@v1
               with:
+                  path: ./dist/plain-js-live-docs
+                  key: ${{github.sha}}-plain-js-live-docs
+            - uses: actions/cache@v1
+              with:
                   path: ./dist/ng-live-docs
-                  key: ${{ github.sha }}-ng-live-docs
+                  key: ${{github.sha}}-ng-live-docs
             - uses: actions/cache@v1
               with:
                   path: ./dist/examples
@@ -67,7 +71,7 @@ jobs:
                   npm ci
                   npm run build-live-docs-doc
                   npm run build-examples-doc
-                  npm run build:example-ng-app
+                  npm run build:example-ng-app-prod
 
     unit-testing:
         runs-on: ubuntu-latest
@@ -79,6 +83,14 @@ jobs:
               with:
                   path: ./coverage
                   key: coverage
+            - uses: actions/cache@v1
+              with:
+                  path: ./dist/plain-js-live-docs
+                  key: ${{github.sha}}-plain-js-live-docs
+            - uses: actions/cache@v1
+              with:
+                path: ./dist/ng-live-docs
+                key: ${{github.sha}}-ng-live-docs
             - name: Run unit-tests
               run: |
                   npm ci
@@ -90,7 +102,7 @@ jobs:
     gh-pages-deploy:
         runs-on: ubuntu-latest
         name: Deploying to Github pages
-        needs: [build-example-ng-app]
+        needs: [build-example-ng-app, unit-testing]
         steps:
             - uses: actions/checkout@v2
             - uses: actions/cache@v1
@@ -105,7 +117,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     publish-plain-js-live-docs:
-        needs: [build-plain-js-live-docs]
+        needs: [build-plain-js-live-docs, build-example-ng-app, unit-testing]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -122,6 +134,8 @@ jobs:
               with:
                   path: ./dist/plain-js-live-docs
                   key: ${{github.sha}}-plain-js-live-docs
+            - name: Install node_modules
+              run: npm ci
             - id: check-plain-js-live-docs-tag
               uses: ./.github/actions/check-lib-tag
               with:
@@ -146,7 +160,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     publish-ng-live-docs:
-      needs: [build-ng-live-docs]
+      needs: [build-ng-live-docs, build-example-ng-app, unit-testing]
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v2
@@ -163,6 +177,8 @@ jobs:
           with:
             path: ./dist/ng-live-docs
             key: ${{github.sha}}-ng-live-docs
+        - name: Install node_modules
+          run: npm ci
         - id: check-ng-live-docs-tag
           uses: ./.github/actions/check-lib-tag
           with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /coverage
 npm-debug.log
 yarn-error.log
+.DS_Store
 
 # Generated Files
 projects/example-ng-app/gen

--- a/angular.json
+++ b/angular.json
@@ -115,7 +115,7 @@
                   "with": "projects/example-ng-app/src/environments/environment.prod.ts"
                 }
               ],
-              "optimization": true,
+              "optimization": false,
               "outputHashing": "all",
               "sourceMap": false,
               "extractCss": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg==",
+      "dev": true
+    },
+    "@actions/github": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.2.0.tgz",
+      "integrity": "sha512-9UAZqn8ywdR70n3GwVle4N8ALosQs4z50N7XMXrSTUVOmVpaBC5kE3TRTT7qQdi3OaQV24mjGuJZsHUmhD+ZXw==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^1.0.3",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/rest": "^16.43.1"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "dev": true,
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@angular-devkit/architect": {
       "version": "0.803.25",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.25.tgz",
@@ -1575,6 +1601,209 @@
         "fastq": "^1.6.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.1.tgz",
+      "integrity": "sha512-NB81O5h39KfHYGtgfWr2booRxp2bWOJoqbWwbyUg2hw6h35ArWYlAST5B3XwAkbdcx13yt84hFXyFP5X0QToWA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^4.0.1"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.2.tgz",
+      "integrity": "sha512-xs1mmCEZ2y4shXCpFjNq3UbmNR+bLzxtZim2L0zfEtj9R6O6kc4qLDvYw66hvO6lUsYzPTM5hMkltbuNAbRAcQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^4.0.1",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.0.tgz",
+      "integrity": "sha512-StJWfn0M1QfhL3NKBz31e1TdDNZrHLLS57J2hin92SIfzlOVBuUaRkp31AGkGOAFOAVtyEX6ZiZcsjcJDjeb5g==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^4.0.1",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+      "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.1",
+        "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.4.tgz",
+      "integrity": "sha512-vqv1lz41c6VTxUvF9nM+a6U+vvP3vGk7drDpr0DVQg4zyqlOiKVrY17DLD6de5okj+YLHKcoqaUZTBtlNZ1BtQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^4.0.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.1.tgz",
+      "integrity": "sha512-5lqBDJ9/TOehK82VvomQ6zFiZjPeSom8fLkFVLuYL3sKiIb5RB8iN/lenLkY7oBmyQcGP7FBMGiIZTO8jufaRQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^4.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.43.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
+      "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/plugin-paginate-rest": "^1.1.1",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
+        "@octokit/request": "^5.2.0",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^2.0.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "@octokit/request-error": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+          "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        },
+        "universal-user-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+          "dev": true,
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
+      }
+    },
+    "@octokit/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-+4X6qfhT/fk/5FD66395NrFLxCzD6FsGlpPwfwvnukdyfYbhiZB/FJltiT1XM5Q63rGGBSf9FPaNV3WpNHm54A==",
+      "dev": true,
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@schematics/angular": {
       "version": "8.3.9",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.9.tgz",
@@ -2481,6 +2710,12 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+      "dev": true
+    },
     "autoprefixer": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
@@ -2696,6 +2931,12 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+      "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
@@ -3045,6 +3286,12 @@
       "requires": {
         "https-proxy-agent": "^2.2.1"
       }
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+      "dev": true
     },
     "buffer": {
       "version": "4.9.2",
@@ -4415,6 +4662,12 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.7.2.tgz",
       "integrity": "sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ==",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
     "des.js": {
@@ -8443,6 +8696,24 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
     "log4js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.5.1.tgz",
@@ -9219,6 +9490,12 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
+    },
     "node-fetch-npm": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
@@ -9556,6 +9833,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
       "dev": true
     },
     "on-finished": {
@@ -13538,6 +13821,12 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -13748,6 +14037,15 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "universal-user-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.1.0"
       }
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,7 +463,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
@@ -800,8 +799,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
-      "dev": true
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
@@ -830,7 +828,6 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
       "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
@@ -840,8 +837,7 @@
         "js-tokens": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         }
       }
     },
@@ -1471,162 +1467,6 @@
       "resolved": "https://registry.npmjs.org/@clr/ui/-/ui-2.2.1.tgz",
       "integrity": "sha512-qLJqnbhM8uLIkRxOwe4hQCQ5P80i3n2U8zB4ekIzuSHcIsLEV7E4UWUSeMhDZhgTvSqHlZrl9DMcY7oP1z+IEA=="
     },
-    "@compodoc/compodoc": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@compodoc/compodoc/-/compodoc-1.1.11.tgz",
-      "integrity": "sha512-3PGTf64Eug1SIcdQole2KkVftBMFjKzecBytLHy4+MQYcblAQM0O3a4GoxuWwN7cTawVq4eqSJTtf6My1I/oHA==",
-      "requires": {
-        "@compodoc/ngd-transformer": "^2.0.0",
-        "chalk": "^2.4.2",
-        "cheerio": "^1.0.0-rc.3",
-        "chokidar": "^3.1.1",
-        "colors": "^1.4.0",
-        "commander": "^3.0.2",
-        "cosmiconfig": "^5.2.1",
-        "decache": "^4.5.1",
-        "fancy-log": "^1.3.3",
-        "findit2": "^2.2.3",
-        "fs-extra": "^8.0.1",
-        "glob": "^7.1.4",
-        "handlebars": "^4.3.3",
-        "html-entities": "^1.2.1",
-        "i18next": "^17.0.16",
-        "inside": "^1.0.0",
-        "json5": "^2.1.0",
-        "live-server": "^1.2.1",
-        "lodash": "^4.17.15",
-        "loglevel": "^1.6.4",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "lunr": "^2.3.6",
-        "marked": "^0.7.0",
-        "minimist": "^1.2.0",
-        "opencollective-postinstall": "^2.0.2",
-        "os-name": "^3.1.0",
-        "pdfmake": "^0.1.60",
-        "semver": "^6.3.0",
-        "traverse": "^0.6.6",
-        "ts-simple-ast": "12.4.0",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.3.0"
-          }
-        },
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
-        },
-        "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "fsevents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
-        "json5": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "readdirp": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
-          "requires": {
-            "picomatch": "^2.0.7"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
-      }
-    },
     "@compodoc/ngd-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@compodoc/ngd-core/-/ngd-core-2.0.0.tgz",
@@ -1712,10 +1552,28 @@
         "webpack-sources": "1.4.3"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
     "@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
     },
     "@schematics/angular": {
       "version": "8.3.9",
@@ -1802,14 +1660,12 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -1834,8 +1690,7 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "8.9.4",
@@ -1847,6 +1702,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/q": {
       "version": "0.0.32",
@@ -2135,9 +1995,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
         }
       }
     },
@@ -2380,6 +2240,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
@@ -2387,7 +2248,8 @@
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
         }
       }
     },
@@ -2417,9 +2279,9 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -3355,6 +3217,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
       "requires": {
         "callsites": "^2.0.0"
       }
@@ -3363,6 +3226,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -3375,7 +3239,8 @@
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -3639,9 +3504,9 @@
       }
     },
     "code-block-writer": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-7.3.1.tgz",
-      "integrity": "sha512-3Jfe6ZmmGzvdQWFo3MUzobn3WdX++jc3Tj0rsviJWYPnP7NGMFEE4qheNeOXeJgB1TTgxYT8XuNvhS/u596yGg=="
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.0.tgz",
+      "integrity": "sha512-RG9hpXtWFeUWhuUav1YuP/vGcyncW+t90yJLk9fNZs1De2OuHTHKAKThVCokt29PYq5RoJ0QSZaIZ+rvPO23hA=="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -4080,6 +3945,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
@@ -4373,9 +4239,9 @@
       "dev": true
     },
     "decache": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
-      "integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.0.tgz",
+      "integrity": "sha512-PppOuLiz+DFeaUvFXEYZjLxAkKiMYH/do/b/MxpDe/8AgKBi5GhZxridoVIbBq72GDbL36e4p0Ce2jTGUwwU+w==",
       "requires": {
         "callsite": "^1.0.0"
       }
@@ -5463,29 +5329,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "falafel": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
-      "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
-      "requires": {
-        "acorn": "^7.1.1",
-        "foreach": "^2.0.5",
-        "isarray": "^2.0.1",
-        "object-keys": "^1.0.6"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
-      }
-    },
     "fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -5504,16 +5347,64 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
-      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
@@ -5532,6 +5423,14 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -5809,115 +5708,32 @@
       }
     },
     "fontkit": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.8.0.tgz",
-      "integrity": "sha512-EFDRCca7khfQWYu1iFhsqeABpi87f03MBdkT93ZE6YhqCdMzb5Eojb6c4dlJikGv5liuhByyzA7ikpIPTSBWbQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.8.1.tgz",
+      "integrity": "sha512-BsNCjDoYRxmNWFdAuK1y9bQt+igIxGtTC9u/jSFjR9MKhmI00rP1fwSvERt+5ddE82544l0XH5mzXozQVUy2Tw==",
       "requires": {
-        "babel-runtime": "^6.11.6",
-        "brfs": "^1.4.0",
+        "babel-runtime": "^6.26.0",
+        "brfs": "^2.0.0",
         "brotli": "^1.2.0",
-        "browserify-optional": "^1.0.0",
-        "clone": "^1.0.1",
+        "browserify-optional": "^1.0.1",
+        "clone": "^1.0.4",
         "deep-equal": "^1.0.0",
-        "dfa": "^1.0.0",
+        "dfa": "^1.2.0",
         "restructure": "^0.5.3",
         "tiny-inflate": "^1.0.2",
-        "unicode-properties": "^1.0.0",
+        "unicode-properties": "^1.2.2",
         "unicode-trie": "^0.3.0"
       },
       "dependencies": {
-        "brfs": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
-          "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
-          "requires": {
-            "quote-stream": "^1.0.1",
-            "resolve": "^1.1.5",
-            "static-module": "^2.2.0",
-            "through2": "^2.0.0"
-          }
-        },
         "clone": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
-        "escodegen": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-          "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
-        "magic-string": {
-          "version": "0.22.5",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-          "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-          "requires": {
-            "vlq": "^0.2.2"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-          "requires": {
-            "source-map": "^0.5.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
-          }
-        },
-        "object-inspect": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
-        },
         "pako": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        },
-        "static-module": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
-          "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
-          "requires": {
-            "concat-stream": "~1.6.0",
-            "convert-source-map": "^1.5.1",
-            "duplexer2": "~0.1.4",
-            "escodegen": "~1.9.0",
-            "falafel": "^2.1.0",
-            "has": "^1.0.1",
-            "magic-string": "^0.22.4",
-            "merge-source-map": "1.0.4",
-            "object-inspect": "~1.4.0",
-            "quote-stream": "~1.0.2",
-            "readable-stream": "~2.3.3",
-            "shallow-copy": "~0.0.1",
-            "static-eval": "^2.0.0",
-            "through2": "~2.0.3"
-          }
         },
         "unicode-trie": {
           "version": "0.3.1",
@@ -5934,11 +5750,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -6055,7 +5866,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6073,11 +5885,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6090,15 +5904,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6201,7 +6018,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6211,6 +6029,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6223,17 +6042,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6250,6 +6072,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -6305,7 +6128,8 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -6330,7 +6154,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6340,6 +6165,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6408,7 +6234,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6438,6 +6265,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6455,6 +6283,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6493,11 +6322,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7065,9 +6896,9 @@
       }
     },
     "i18next": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-17.3.1.tgz",
-      "integrity": "sha512-4nY+yaENaoZKmpbiDXPzucVHCN3hN9Z9Zk7LyQXVOKVIpnYOJ3L/yxHJlBPtJDq3PGgjFwA0QBFm/26Z0iDT5A==",
+      "version": "19.4.5",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.4.5.tgz",
+      "integrity": "sha512-aLvSsURoupi3x9IndmV6+m3IGhzLzhYv7Gw+//K3ovdliyGcFRV0I1MuddI0Bk/zR7BG1U+kJOjeHFUcUIdEgg==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -7133,6 +6964,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
       "requires": {
         "caller-path": "^2.0.0",
         "resolve-from": "^3.0.0"
@@ -7451,7 +7283,8 @@
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -7948,6 +7781,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -8447,8 +8281,7 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "lit-html": {
       "version": "1.1.2",
@@ -9166,14 +8999,27 @@
       "dev": true
     },
     "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+        },
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        }
       }
     },
     "mute-stream": {
@@ -10014,6 +9860,21 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+        }
+      }
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -10032,6 +9893,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -10967,6 +10829,205 @@
         }
       }
     },
+    "rbradford-compodoc": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/rbradford-compodoc/-/rbradford-compodoc-1.1.11.tgz",
+      "integrity": "sha512-YmiV+Eip0Rqj2C1tV2obvoJfyjM0dmp/BcPi4nyGqSRJkP1Sdyj3H5OXi5NOWe/E7ibicALesAl5gOf+ZuOutg==",
+      "requires": {
+        "@compodoc/ngd-transformer": "^2.0.0",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.3",
+        "chokidar": "^3.3.0",
+        "colors": "^1.4.0",
+        "commander": "^4.0.0",
+        "cosmiconfig": "^6.0.0",
+        "decache": "^4.5.1",
+        "fancy-log": "^1.3.3",
+        "findit2": "^2.2.3",
+        "fs-extra": "^8.0.1",
+        "glob": "^7.1.5",
+        "handlebars": "^4.5.1",
+        "html-entities": "^1.2.1",
+        "i18next": "^19.0.0",
+        "inside": "^1.0.0",
+        "json5": "^2.1.1",
+        "live-server": "^1.2.1",
+        "lodash": "^4.17.15",
+        "loglevel": "^1.6.4",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "lunr": "^2.3.8",
+        "marked": "^0.7.0",
+        "minimist": "^1.2.0",
+        "opencollective-postinstall": "^2.0.2",
+        "os-name": "^3.1.0",
+        "pdfmake": "^0.1.62",
+        "semver": "^6.3.0",
+        "traverse": "^0.6.6",
+        "ts-morph": "^4.3.2",
+        "ts-simple-ast": "12.4.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11328,7 +11389,8 @@
     "resolve-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -11372,6 +11434,11 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rfdc": {
       "version": "1.1.4",
@@ -11487,6 +11554,11 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "run-queue": {
       "version": "1.0.3",
@@ -12304,8 +12376,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -12484,49 +12555,44 @@
       }
     },
     "static-module": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.3.tgz",
-      "integrity": "sha512-RDaMYaI5o/ym0GkCqL/PlD1Pn216omp8fY81okxZ6f6JQxWW5tptOw9reXoZX85yt/scYvbWIt6uoszeyf+/MQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
+      "integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
       "requires": {
         "acorn-node": "^1.3.0",
         "concat-stream": "~1.6.0",
         "convert-source-map": "^1.5.1",
         "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
+        "escodegen": "^1.11.1",
         "has": "^1.0.1",
-        "magic-string": "^0.22.4",
+        "magic-string": "0.25.1",
         "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
+        "object-inspect": "^1.6.0",
         "readable-stream": "~2.3.3",
         "scope-analyzer": "^2.0.1",
         "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.2",
+        "static-eval": "^2.0.5",
         "through2": "~2.0.3"
       },
       "dependencies": {
         "escodegen": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+          "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
           "requires": {
-            "esprima": "^3.1.3",
+            "esprima": "^4.0.1",
             "estraverse": "^4.2.0",
             "esutils": "^2.0.2",
             "optionator": "^0.8.1",
             "source-map": "~0.6.1"
           }
         },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
         "magic-string": {
-          "version": "0.22.5",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-          "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+          "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
           "requires": {
-            "vlq": "^0.2.2"
+            "sourcemap-codec": "^1.4.1"
           }
         },
         "merge-source-map": {
@@ -12543,11 +12609,6 @@
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             }
           }
-        },
-        "object-inspect": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
         },
         "source-map": {
           "version": "0.6.1",
@@ -13188,6 +13249,85 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "ts-morph": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-4.3.3.tgz",
+      "integrity": "sha512-yauxRJM4Vo+KvpJFgL4Mp9PtFjwZVrt54eP3RkLIXnaaAY5TGVHTLqN2OnLGwf6YjyqkDLAKprZVOUTvVEz6ZQ==",
+      "requires": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "chalk": "^2.4.2",
+        "code-block-writer": "^10.0.0",
+        "fs-extra": "^8.1.0",
+        "glob-parent": "^5.1.0",
+        "globby": "^10.0.1",
+        "is-negated-glob": "^1.0.0",
+        "multimatch": "^4.0.0",
+        "typescript": "3.0.1 - 3.6.4"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+          "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
+          "integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA=="
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+        }
+      }
+    },
     "ts-node": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.0.tgz",
@@ -13239,6 +13379,21 @@
         "typescript": "2.9.1"
       },
       "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+        },
+        "code-block-writer": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-7.3.1.tgz",
+          "integrity": "sha512-3Jfe6ZmmGzvdQWFo3MUzobn3WdX++jc3Tj0rsviJWYPnP7NGMFEE4qheNeOXeJgB1TTgxYT8XuNvhS/u596yGg=="
+        },
         "dir-glob": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
@@ -13246,6 +13401,19 @@
           "requires": {
             "arrify": "^1.0.1",
             "path-type": "^3.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
           }
         },
         "fs-extra": {
@@ -13270,6 +13438,17 @@
             "ignore": "^3.3.5",
             "pify": "^3.0.0",
             "slash": "^1.0.0"
+          }
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+          "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
           }
         },
         "pify": {
@@ -13411,8 +13590,7 @@
     "typescript": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-      "dev": true
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
     },
     "uglify-js": {
       "version": "3.8.1",
@@ -13821,11 +13999,6 @@
       "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.2.tgz",
       "integrity": "sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ=="
     },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
-    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -14157,9 +14330,9 @@
       }
     },
     "windows-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
+      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
       "requires": {
         "execa": "^1.0.0"
       }
@@ -14312,6 +14485,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "npm run build:plainjs; npm run build:ng-live-docs; npm run build-live-docs-doc; npm run build-examples-doc; ng serve",
     "build": "ng build",
     "build:example-ng-app": "ng build example-ng-app",
+    "build:example-ng-app-prod": "ng build example-ng-app --prod",
     "build:plainjs": "ng build plain-js-live-docs",
     "build:ng-live-docs": "ng build ng-live-docs; tsc -p projects/ng-live-docs/scripts/tsconfig.json",
     "test": "ng test",
@@ -42,6 +43,8 @@
     "zone.js": "0.9.1"
   },
   "devDependencies": {
+    "@actions/core": "^1.2.4",
+    "@actions/github": "^2.2.0",
     "@angular-devkit/build-angular": "0.803.25",
     "@angular-devkit/build-ng-packagr": "0.803.25",
     "@angular/cli": "8.3.9",
@@ -56,18 +59,18 @@
     "karma": "4.1.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "2.0.1",
+    "karma-coverage-istanbul-reporter": "2.1.1",
     "karma-jasmine": "2.0.1",
     "karma-jasmine-html-reporter": "1.4.0",
     "ng-packagr": "5.4.0",
+    "prettier": "1.18.2",
+    "pretty-quick": "2.0.0",
     "protractor": "5.4.0",
     "ts-node": "7.0.0",
     "tsickle": "0.37.1",
     "tslint": "5.15.0",
-    "typescript": "3.5.3",
-    "karma-coverage-istanbul-reporter": "2.1.1",
-    "prettier": "1.18.2",
-    "pretty-quick": "2.0.0",
-    "tslint-microsoft-contrib": "6.2.0"
+    "tslint-microsoft-contrib": "6.2.0",
+    "typescript": "3.5.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
     "@clr/angular": "2.2.1",
     "@clr/icons": "2.2.1",
     "@clr/ui": "2.2.1",
-    "@compodoc/compodoc": "1.1.11",
     "@stackblitz/sdk": "1.3.0",
+    "@webcomponents/custom-elements": "1.0.0",
+    "angular-cli-ghpages": "0.6.2",
     "lit-html": "1.1.2",
     "prismjs": "1.17.1",
+    "rbradford-compodoc": "1.1.11",
     "rxjs": "6.4.0",
     "tslib": "1.10.0",
-    "zone.js": "0.9.1",
-    "@webcomponents/custom-elements": "1.0.0",
-    "angular-cli-ghpages": "0.6.2"
+    "zone.js": "0.9.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.803.25",

--- a/projects/example-ng-app/tsconfig.app.json
+++ b/projects/example-ng-app/tsconfig.app.json
@@ -13,6 +13,6 @@
   ],
   "exclude": [
     "src/test.ts",
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
   ]
 }

--- a/projects/ng-live-docs/README.md
+++ b/projects/ng-live-docs/README.md
@@ -44,7 +44,11 @@ Please refer to [apiviewer example](../example-ng-app/src/example-components/api
 
 ## Hosting Compodoc (optional)
 
-- Optionally, your application can host compodoc to allow the type arguments in the API viewer to link to more extensive documentation. To do this generate the compodoc by running `compodoc -p tsconfig.json` in your relevant library. Add this generated folder to the assets of your Angular app.
+Your application may host compodoc to allow the type arguments in the API viewer to link to more extensive documentation. To do:
+
+- Generate the compodoc by running compodoc -p tsconfig.json in your relevant library.
+- Add this generated folder to the assets of your Angular app
+- Pass an extra argument to NgLiveDocsModule.forRoot to indicate the the URL of compodoc assets
 
 #### App entry module changes:
 - Import the generated doc jsons into app.module.ts as following
@@ -77,10 +81,10 @@ Please refer to [apiviewer example](../example-ng-app/src/example-components/api
             moduleFinder?(componentName: string): string;
         };
 
-- Recall the asset URL that you hosted the Compodoc at. That will be passed below. 
+- Recall the asset URL that you hosted the Compodoc at. This URL is relative to the base URL of the Angular app. For example, if we hosted the "compodoc" located at "assets/compodoc" from the assets file in Angular.json, we would provide "compodoc" That will be passed below. 
 
 
-- Provide the above 4 resources (2 docJsons, sbInfo, assetUrl) to the NgLiveDocs module inside AppModule
+- Provide the above resources (2 docJsons, sbInfo, assetUrl) to the NgLiveDocs module inside AppModule
 
         @NgModule({
             ...

--- a/projects/ng-live-docs/README.md
+++ b/projects/ng-live-docs/README.md
@@ -42,6 +42,10 @@ in the following way:
 
 Please refer to [apiviewer example](../example-ng-app/src/example-components/apiviewer) to get an idea about how to create an example and its module
 
+## Hosting Compodoc (optional)
+
+- Optionally, your application can host compodoc to allow the type arguments in the API viewer to link to more extensive documentation. To do this generate the compodoc by running `compodoc -p tsconfig.json` in your relevant library. Add this generated folder to the assets of your Angular app.
+
 #### App entry module changes:
 - Import the generated doc jsons into app.module.ts as following
 
@@ -73,14 +77,16 @@ Please refer to [apiviewer example](../example-ng-app/src/example-components/api
             moduleFinder?(componentName: string): string;
         };
 
+- Recall the asset URL that you hosted the Compodoc at. That will be passed below. 
 
-- Provide the above 3 resources(2 docJsons and sbInfo) to the NgLiveDocs module inside AppModule
+
+- Provide the above 4 resources (2 docJsons, sbInfo, assetUrl) to the NgLiveDocs module inside AppModule
 
         @NgModule({
             ...
             imports: [
                 ...
-                NgLiveDocsModule.forRoot([docJson1, docJson2], sbInfo),
+                NgLiveDocsModule.forRoot([docJson1, docJson2], sbInfo, assetUrl),
                 ...
             ],
             ...

--- a/projects/ng-live-docs/ng-package.json
+++ b/projects/ng-live-docs/ng-package.json
@@ -5,7 +5,7 @@
     "entryFile": "src/public-api.ts"
   },
   "whitelistedNonPeerDependencies": [
-    "@compodoc/compodoc",
+    "rbradford-compodoc",
     "@stackblitz/sdk",
     "@vmw/plain-js-live-docs"
   ]

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "peerDependencies": {
     "@angular/common": "8.2.8",
     "@angular/core": "8.2.8",

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "peerDependencies": {
     "@angular/common": "8.2.8",
     "@angular/core": "8.2.8",

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -10,7 +10,7 @@
     "@clr/icons": "^2"
   },
   "dependencies": {
-    "@compodoc/compodoc": "1.1.11",
+    "rbradford-compodoc": "1.1.11",
     "@stackblitz/sdk": "1.3.0",
     "@vmw/plain-js-live-docs": "0.0.1"
   }

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.html
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.html
@@ -12,7 +12,10 @@
             <td class="left">
                 <p>{{ par.name }}</p>
             </td>
-            <td>{{ par.type }}</td>
+            <td>
+                <p *ngIf="!compodocUrl || !par.typeLink">{{ par.type }}</p>
+                <a *ngIf="compodocUrl && par.typeLink" [href]="compodocUrl + '/' + par.typeLink">{{ par.type }}</a>
+            </td>
             <td class="left"><div [innerHTML]="par.description"></div></td>
         </tr>
     </tbody>
@@ -33,7 +36,10 @@
             <td class="left">
                 <p>{{ par.name }}</p>
             </td>
-            <td>{{ par.type }}</td>
+            <td>
+                <p *ngIf="!compodocUrl || !par.typeLink">{{ par.type }}</p>
+                <a *ngIf="compodocUrl && par.typeLink" [href]="compodocUrl + '/' + par.typeLink">{{ par.type }}</a>
+            </td>
             <td class="left"><div [innerHTML]="par.description"></div></td>
         </tr>
     </tbody>

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.html
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.html
@@ -38,7 +38,7 @@
             </td>
             <td>
                 <p *ngIf="!compodocUrl || !par.typeLink">{{ par.type }}</p>
-                <a *ngIf="compodocUrl && par.typeLink" [href]="compodocUrl + '/' + par.typeLink">{{ par.type }}</a>
+                <a *ngIf="compodocUrl && par.typeLink" [href]="'../' + compodocUrl + '/' + par.typeLink">{{ par.type }}</a>
             </td>
             <td class="left"><div [innerHTML]="par.description"></div></td>
         </tr>

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.html
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.html
@@ -38,7 +38,7 @@
             </td>
             <td>
                 <p *ngIf="!compodocUrl || !par.typeLink">{{ par.type }}</p>
-                <a *ngIf="compodocUrl && par.typeLink" [href]="'../' + compodocUrl + '/' + par.typeLink">{{ par.type }}</a>
+                <a *ngIf="compodocUrl && par.typeLink" [href]="compodocUrl + '/' + par.typeLink">{{ par.type }}</a>
             </td>
             <td class="left"><div [innerHTML]="par.description"></div></td>
         </tr>

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.spec.ts
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.spec.ts
@@ -6,7 +6,4 @@
 import {ApiViewerComponent} from './api-viewer.component';
 
 describe('ApiViewerComponent', () => {
-    it('needs at least one test', () => {
-        expect(1).toEqual(1);
-    });
 });

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.spec.ts
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.spec.ts
@@ -5,4 +5,8 @@
 
 import {ApiViewerComponent} from './api-viewer.component';
 
-describe('ApiViewerComponent', () => {});
+describe('ApiViewerComponent', () => {
+    it('needs at least one test', () => {
+        expect(1).toEqual(1);
+    });
+});

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.ts
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.ts
@@ -8,7 +8,7 @@ import {ApiParameters, DocumentationRetrieverService} from '../documentation-ret
 import { COMPODOC_URL } from '../ng-live-docs.module';
 
 @Component({
-    selector: ' vmw-api-viewer',
+    selector: 'vmw-api-viewer',
     templateUrl: './api-viewer.component.html',
     styleUrls: ['./api-viewer.component.scss'],
 })

--- a/projects/ng-live-docs/src/api-viewer/api-viewer.component.ts
+++ b/projects/ng-live-docs/src/api-viewer/api-viewer.component.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import {Component, Input, Type} from '@angular/core';
+import {Component, Inject, Input, Type} from '@angular/core';
 import {ApiParameters, DocumentationRetrieverService} from '../documentation-retriever.service';
+import { COMPODOC_URL } from '../ng-live-docs.module';
 
 @Component({
     selector: ' vmw-api-viewer',
@@ -15,7 +16,10 @@ export class ApiViewerComponent {
     inputParameters: ApiParameters[];
     outputParameters: ApiParameters[];
 
-    constructor(private documentationRetriever: DocumentationRetrieverService) {}
+    constructor(
+        private documentationRetriever: DocumentationRetrieverService,
+        @Inject(COMPODOC_URL) public compodocUrl: string,
+        ) {}
 
     /**
      * Gets the input and output parameters from the Compodoc generated documentation json

--- a/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.spec.ts
+++ b/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.spec.ts
@@ -3,7 +3,92 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { Type } from '@angular/core';
 import {CompoDocRetrieverService} from './compodoc-retriever.service';
+import { CompodocSchema } from './compodoc-schema';
 
-describe('CompoDocRetrieverService', () => {
+const DOCUMENTATION: CompodocSchema[] = [{
+    components: [{
+        name: 'comp',
+        description: '',
+        sourceCode: '',
+        templateUrl: [],
+        templateData: '',
+        styleUrls: [],
+        styleUrlsData: [],
+        inputsClass: [{
+            name: 'param',
+            type: 'SomeInterface',
+            description: '',
+        },
+        {
+            name: 'param2',
+            type: 'SomeType',
+            description: '',
+        }],
+        outputsClass: [{
+            name: 'param',
+            type: 'SomeInterface',
+            description: '',
+        },
+        {
+            name: 'param2',
+            type: 'SomeType',
+            description: '',
+        }],
+        file: '',
+        selector: '',
+    }],
+    modules: [],
+    interfaces: [{
+        name: 'SomeInterface'
+    }],
+    injectables: [],
+    classes: [],
+    directives: [],
+    miscellaneous: {
+        variables: [],
+        functions: [],
+        typealiases: [{
+            name: 'SomeType',
+        }],
+        enumerations: [],
+    }
+}];
+
+fdescribe('CompoDocRetrieverService', () => {
+
+    const compoDocRetrieverService = new CompoDocRetrieverService(DOCUMENTATION);
+
+    describe('getInputParameters', () => {
+        it('adds the type link for a linked interface', () => {
+            const inputs = compoDocRetrieverService.getInputParameters({
+                name: 'comp'
+            } as Type<unknown>);
+            expect(inputs[0].typeLink).toEqual('interfaces/SomeInterface.html');
+        });
+
+        it('adds the type link for a linked type', () => {
+            const inputs = compoDocRetrieverService.getInputParameters({
+                name: 'comp'
+            } as Type<unknown>);
+            expect(inputs[1].typeLink).toEqual('miscellaneous/typealiases.html#SomeType');
+        });
+    });
+
+    describe('getOutputParameters', () => {
+        it('adds the type link for a linked interface', () => {
+            const outputs = compoDocRetrieverService.getOutputParameters({
+                name: 'comp'
+            } as Type<unknown>);
+            expect(outputs[0].typeLink).toEqual('interfaces/SomeInterface.html');
+        });
+
+        it('adds the type link for a linked type', () => {
+            const outputs = compoDocRetrieverService.getOutputParameters({
+                name: 'comp'
+            } as Type<unknown>);
+            expect(outputs[1].typeLink).toEqual('miscellaneous/typealiases.html#SomeType');
+        });
+    });
 });

--- a/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.spec.ts
+++ b/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.spec.ts
@@ -56,7 +56,7 @@ const DOCUMENTATION: CompodocSchema[] = [{
     }
 }];
 
-fdescribe('CompoDocRetrieverService', () => {
+describe('CompoDocRetrieverService', () => {
 
     const compoDocRetrieverService = new CompoDocRetrieverService(DOCUMENTATION);
 

--- a/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.ts
+++ b/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.ts
@@ -80,17 +80,15 @@ export class CompoDocRetrieverService implements DocumentationRetrieverService {
      * for example "compodoc/classes/ColumnConfig" or "compodoc/types#ColumnConfigType"
      */
     private getTypeLink(type: string): string {
-        // Extract the outermost Typescript type of the given type string.
         const rawType = type.split('[')[0].split('<')[0];
-        // Check every documentation JSON registered with the library
         const found = this.traverseDocumentation((item) => item.name === rawType);
         if (!found) {
             return '';
         }
         if (MISCELLANEOUS_LEVEL_TYPES.indexOf(found.itemType) !== -1) {
-            return 'miscellaneous' + '/' + found.itemType + '.html#' + found.name;
+            return `miscellaneous/${found.itemType}.html#${found.name}`;
         }
-        return found.itemType + '/' + found.name + '.html';
+        return `${found.itemType}/${found.name}.html`;
     }
 
     /**

--- a/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.ts
+++ b/projects/ng-live-docs/src/compodoc/compodoc-retriever.service.ts
@@ -68,16 +68,22 @@ export class CompoDocRetrieverService implements DocumentationRetrieverService {
     }
 
     private getTypeLink(type: string): string {
+        // Extract the outermost Typescript type of the given type string.
         const rawType = type.split('[')[0].split('<')[0];
+        // Check every documentation JSON registered with the library.
         for (const documentationJson of this.documentationJson) {
+            // Check every documentation type in the given documentation
             for (const typeLink of Object.keys(documentationJson)) {
+                // If it is a list, attempt to find the given raw type
                 if (documentationJson[typeLink].find) {
                     const typeDoc = documentationJson[typeLink].find(c => c.name === rawType);
                     if (typeDoc) {
                         return typeLink + '/' + rawType + '.html';
                     }
                 } else {
+                    // Else check one level deeper because it is the 'miscellaneous' section.
                     for (const innerTypeLink of Object.keys(documentationJson[typeLink])) {
+                        // If it is an array, find the given raw type.
                         if (documentationJson[typeLink][innerTypeLink].find) {
                             const typeDoc = documentationJson[typeLink][innerTypeLink].find(c => c.name === rawType);
                             if (typeDoc) {

--- a/projects/ng-live-docs/src/compodoc/compodoc-schema.ts
+++ b/projects/ng-live-docs/src/compodoc/compodoc-schema.ts
@@ -15,13 +15,38 @@ import {ApiParameters} from '../documentation-retriever.service';
 export interface CompodocSchema {
     components: CompodocComponent[];
     modules: CompodocModule[];
+    interfaces: RawGenericCompodocItem[];
+    injectables: RawGenericCompodocItem[];
+    classes: RawGenericCompodocItem[];
+    directives: RawGenericCompodocItem[];
+    miscellaneous: {
+        variables: RawGenericCompodocItem[];
+        functions: RawGenericCompodocItem[];
+        typealiases: RawGenericCompodocItem[];
+        enumerations: RawGenericCompodocItem[];
+    };
+}
+
+export interface RawGenericCompodocItem {
+    name: string;
+}
+
+export interface GenericCompodocItem {
+    /**
+     * The name of this Compodoc item.
+     */
+    name: string;
+    /**
+     * Key that this object is located at within the Compodoc JSON, e.g., variables, directives, components.
+     * Could be top level or under miscellaneous (variables, functions, typealiases, enumerations)
+     */
+    itemType: string;
 }
 
 /**
  * Component description as defined in the Compodoc generated documentation JSON
  */
-export interface CompodocComponent {
-    name: string;
+export interface CompodocComponent extends RawGenericCompodocItem {
     description: string;
     sourceCode: string;
     templateUrl: string[];
@@ -34,11 +59,7 @@ export interface CompodocComponent {
     selector: string;
 }
 
-export interface CompodocModule {
-    /**
-     * Name of the class that has the @NgModule() declaration
-     */
-    name: string;
+export interface CompodocModule extends RawGenericCompodocItem {
     path: string;
     sourceCode: string;
     children: {

--- a/projects/ng-live-docs/src/documentation-retriever.service.ts
+++ b/projects/ng-live-docs/src/documentation-retriever.service.ts
@@ -21,7 +21,7 @@ export interface ApiParameters {
     /**
      * Represents the link type of object this is as taken from Compodoc.
      */
-    linkType: string;
+    typeLink?: string;
     /**
      * Represents JS doc of input/output property
      */

--- a/projects/ng-live-docs/src/documentation-retriever.service.ts
+++ b/projects/ng-live-docs/src/documentation-retriever.service.ts
@@ -19,6 +19,10 @@ export interface ApiParameters {
      */
     type: string;
     /**
+     * Represents the link type of object this is as taken from Compodoc.
+     */
+    linkType: string;
+    /**
      * Represents JS doc of input/output property
      */
     description: string;

--- a/projects/ng-live-docs/src/ng-live-docs.module.ts
+++ b/projects/ng-live-docs/src/ng-live-docs.module.ts
@@ -24,6 +24,11 @@ export const DOCUMENTATION_DATA = new InjectionToken<CompodocSchema[]>(
 );
 
 /**
+ * A token that is used to provide the url where the raw compodoc output is located.
+ */
+export const COMPODOC_URL = new InjectionToken<string>('COMPODOC_URL');
+
+/**
  * Token that makes Stqckblitz JSON data available to factory functions
  */
 export const STACKBLITZ_DATA = new InjectionToken<StackBlitzInfo>(
@@ -51,7 +56,7 @@ export class NgLiveDocsModule {
      * Called in the host package importing this doc library for providing the documentation JSONs needed for
      * {@link CompoDocRetrieverService}
      */
-    public static forRoot(documentations: CompodocSchema[], stackblitzData: StackBlitzInfo): ModuleWithProviders {
+    public static forRoot(documentations: CompodocSchema[], stackblitzData: StackBlitzInfo, compodocUrl?: string): ModuleWithProviders {
         return {
             ngModule: NgLiveDocsModule,
             providers: [
@@ -74,6 +79,10 @@ export class NgLiveDocsModule {
                     deps: [STACKBLITZ_INFO, DocumentationRetrieverService],
                     useFactory: getStackBlitzWriter,
                 },
+                {
+                    provide: COMPODOC_URL,
+                    useValue: compodocUrl
+                }
             ],
         };
     }


### PR DESCRIPTION
# Description 

Changes live docs to have the type column optionally link to the actual Comodoc documentation.
Also changes to use our own version of Comodoc that fixes bugs with default values and setters. 

Relevant Compodoc Review: https://github.com/ryan-bradford/compodoc/pull/1

# Testing

Linked with the @vcd/ui-components examples application and verified the following:

1. On the datagrid page, the type of the setter buttonConfig appears as ButtonConfig and when clicking the link it brings you to http://localhost:4200/compodoc/interfaces/ButtonConfig.html.
2. On the data exporter page, the type of cancelText appears as LazyString and clicking brings you to http://localhost:4200/compodoc/miscellaneous/typealiases.html#LazyString
3. On the datagrid page, the type of the columns setter appears as GridColumn[] and clicking links to http://localhost:4200/compodoc/interfaces/GridColumn.html
4. On the form select page, showAsterisk appears as a boolean even though it uses a default value.
5. On the form input page, hintPosition appears as a string even though it uses a default value.

# Problems:

1. Cannot link to Types not in the current library.
2. Only links to the most-outer type. I.E. `TypeA<TypeB> would only link to the documentation for TypeA.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>