### PR TITLE
Add selector prop back to _name@dasherize_example.component.ts.template

### DIFF
--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
     "copy:schemas": "rsync -Rr schematics/*/schema.json ../../dist/ng-live-docs/",

--- a/projects/ng-live-docs/schematics/add-example/files/example-component/__name@dasherize__.example.component.ts.template
+++ b/projects/ng-live-docs/schematics/add-example/files/example-component/__name@dasherize__.example.component.ts.template
@@ -6,6 +6,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
+    selector: 'vcd-<%= dasherize(name) %>-example',
     templateUrl: './<%= dasherize(name) %>.example.component.html',
     styleUrls: ['./<%= dasherize(name) %>.example.component.scss'],
 })


### PR DESCRIPTION
Because, without the selector, although we are able to see the example in the examples container, it will not work on the Stackblitz website