### PR TITLE
Bump version to @vmw/ng-live-docs@0.0.11

### DIFF
--- a/projects/ng-live-docs/CHANGELOG.md
+++ b/projects/ng-live-docs/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.0.10]
+## [0.0.11]
 
 ### Changed
 

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
     "copy:schemas": "rsync -Rr schematics/*/schema.json ../../dist/ng-live-docs/",


### PR DESCRIPTION
This should have been done in the previous commit but
was ommitted by accident.

Signed-off-by: Juan Mendes <mendejuan@gmail.com>