### PR TITLE
Bump versions for both libraries

### DIFF
--- a/projects/ng-live-docs/CHANGELOG.md
+++ b/projects/ng-live-docs/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [0.0.12]
 
-Publishing with `@latest`
+### Changed
+Updated to require @vmw/plain-js-livedocs@0.0.4 which has more liberal peer dependencies
 
 ## [0.0.11]
 

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
     "copy:schemas": "rsync -Rr schematics/*/schema.json ../../dist/ng-live-docs/",

--- a/projects/plain-js-live-docs/CHANGELOG.md
+++ b/projects/plain-js-live-docs/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.0.4]
+### Changed
+-  Fixed peer dependencies
+
+
 ## [0.0.3]
 
 ### Changed

--- a/projects/plain-js-live-docs/package.json
+++ b/projects/plain-js-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/plain-js-live-docs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "peerDependencies": {
     "@clr/ui": "^5",
     "@clr/icons": "^5",


### PR DESCRIPTION
The previous commit fixed peer dependencies on @vmw/plain-js-live-docs

Signed-off-by: Juan Mendes <mendejuan@gmail.com>