### PR TITLE
Fix peer dependencies

### DIFF
--- a/projects/ng-live-docs/CHANGELOG.md
+++ b/projects/ng-live-docs/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.0.11]
+
+### Changed
+
+Updated to require @vmw/plain-js-livedocs@0.0.4 which has more liberal peer dependencies
+
 ## [0.0.10]
 
 ### Changed

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
     "copy:schemas": "rsync -Rr schematics/*/schema.json ../../dist/ng-live-docs/",
@@ -19,10 +19,9 @@
   },
   "dependencies": {
     "rbradford-compodoc": "1.1.11",
-    "@stackblitz/sdk": "1.3.0",
-    "@vmw/plain-js-live-docs": "0.0.3",
-    "schematics-utilities": "2.0.2",
-    "tslib": "^2.0.0"
+    "@stackblitz/sdk": "^1.3",
+    "@vmw/plain-js-live-docs": "^0.0.4",
+    "schematics-utilities": "^2"
   },
   "schematics": "./schematics/collection.json"
 }

--- a/projects/plain-js-live-docs/CHANGELOG.md
+++ b/projects/plain-js-live-docs/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.0.4]
+
+### Changed
+
+-   Fixed peer dependencies
+
 ## [0.0.3]
+
+DO NOT USE. Bad peer dependencies.
 
 ### Changed
 

--- a/projects/plain-js-live-docs/ng-package.json
+++ b/projects/plain-js-live-docs/ng-package.json
@@ -3,9 +3,5 @@
   "dest": "../../dist/plain-js-live-docs",
   "lib": {
     "entryFile": "src/public-api.ts"
-  },
-  "whitelistedNonPeerDependencies": [
-    "lit-html",
-    "prismjs"
-  ]
+  }
 }

--- a/projects/plain-js-live-docs/package.json
+++ b/projects/plain-js-live-docs/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@vmw/plain-js-live-docs",
-  "version": "0.0.3",
-  "dependencies": {
-    "tslib": "^2.0.0"
-  },
+  "version": "0.0.4",
   "peerDependencies": {
     "@clr/ui": "^5",
     "@clr/icons": "^5",
     "@cds/core": "^5",
-    "lit-html": "1.1.2",
-    "prismjs": "1.17.1"
+    "lit-html": "^1",
+    "prismjs": "^1"
   }
 }


### PR DESCRIPTION
Previous strict peer dependencies were causing conflicts with Clarity's.

Peer dependencies should not be too strict.

Signed-off-by: Juan Mendes <mendejuan@gmail.com>