### PR TITLE
Publishing first good versions after ng11 upgrade

### DIFF
--- a/projects/ng-live-docs/CHANGELOG.md
+++ b/projects/ng-live-docs/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.0.11]
+## [0.0.13]
+
+The first good version after problems with the pipeline. Version to be used for  
+Angular 11 / Clarity 5
 
 ### Changed
 

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
     "copy:schemas": "rsync -Rr schematics/*/schema.json ../../dist/ng-live-docs/",
@@ -20,7 +20,7 @@
   "dependencies": {
     "rbradford-compodoc": "1.1.11",
     "@stackblitz/sdk": "^1.3",
-    "@vmw/plain-js-live-docs": "^0.0.4",
+    "@vmw/plain-js-live-docs": "^0.0.5",
     "schematics-utilities": "^2"
   },
   "schematics": "./schematics/collection.json"

--- a/projects/plain-js-live-docs/CHANGELOG.md
+++ b/projects/plain-js-live-docs/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.0.4]
+## [0.0.5]
+
+Upgraded to Angular 11 / Clarity 5
 
 ### Changed
 

--- a/projects/plain-js-live-docs/package.json
+++ b/projects/plain-js-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/plain-js-live-docs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "peerDependencies": {
     "@clr/ui": "^5",
     "@clr/icons": "^5",


### PR DESCRIPTION
After a bug with our publishing pipeline, these should be the versions to use with Clarity 5 and Angular 11.