### PR TITLE
Changing publishing to be based on magic strings in commit message

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -150,7 +150,10 @@ jobs:
               uses: codecov/codecov-action@v1
 
     publish-plain-js-live-docs:
-        needs: [build-plain-js-live-docs, unit-testing]
+        if: contains(github.event.head_commit.message, '[publish @vmw/plain-js-live-docs')
+            && github.event_name == 'push'
+            && github.ref == 'refs/heads/master'
+        needs: [build-plain-js-live-docs]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -174,18 +177,8 @@ jobs:
                   path: ./dist/plain-js-live-docs
                   key: ${{github.sha}}-plain-js-live-docs
 
-            - name: Check if package.json changed
-              id: check-version
-              uses: EndBug/version-check@v2
-              with:
-                  diff-search: true
-                  file-name: ./projects/plain-js-live-docs/package.json
-
             - name: Publish plain-js-live-docs@next
-              if: steps.check-version.outputs.changed == 'true'
-                  && endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vmw/plain-js-live-docs]')
               run: |
                   cd ./dist/plain-js-live-docs
                   npm publish --tag next --access public
@@ -193,10 +186,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
             - name: Publish plain-js-live-docs@latest
-              if: steps.check-version.outputs.changed == 'true'
-                  && !endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vmw/plain-js-live-docs@latest]')
               run: |
                   cd ./dist/plain-js-live-docs
                   npm publish
@@ -204,6 +194,9 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     publish-ng-live-docs:
+        if: contains(github.event.head_commit.message, '[publish @vmw/ng-live-docs')
+            && github.event_name == 'push'
+            && github.ref == 'refs/heads/master'
         needs: [build-ng-live-docs, unit-testing]
         runs-on: ubuntu-latest
         steps:
@@ -228,18 +221,8 @@ jobs:
                   path: ./dist/ng-live-docs
                   key: ${{github.sha}}-ng-live-docs
 
-            - name: Check if package.json changed
-              id: check-version
-              uses: EndBug/version-check@v2
-              with:
-                  diff-search: true
-                  file-name: ./projects/ng-live-docs/package.json
-
             - name: Publish ng-live-docs@next
-              if: steps.check-version.outputs.changed == 'true'
-                  && endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vmw/ng-live-docs]')
               run: |
                   cd ./dist/ng-live-docs
                   npm publish --tag next --access public
@@ -247,10 +230,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
             - name: Publish ng-live-docs@latest
-              if: steps.check-version.outputs.changed == 'true'
-                  && !endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vmw/ng-live-docs@latest]')
               run: |
                   cd ./dist/ng-live-docs
                   npm publish

--- a/README.md
+++ b/README.md
@@ -45,13 +45,21 @@ of a WidgetObject pattern to minimize duplication of code accessing HTML in test
 
 ## Publishing
 
--   Make a change to [projects/ng-live-docs/package.json](./projects/ng-live-docs/package.json) or
-    [projects/plain-js-live-docs/package.json](./projects/plain-live-docs/package.json).
--   Create a PR
--   When the PR is merged, an action will run and publish the packages to npm.
-    -   By creating a version that ends with `next`, for example `"version" : "1.2.3-next""`, the npm version will be tagged
-        with `@next`
-    -   Versions that don't end with `next` will be published without a tag, which means it will be considered `@latest`.
+We recommend that a separate PR be created when publishing a new version of the library. To publish a new version
+of `@vmw/plain-js-live-docs` or `@vmw/ng-live-docs`, you must add the following anywhere in your commit message:
+
+-   `[publish @vmw/plain-js-live-docs]` to publish @vmw/plain-js-live-docs@next
+-   `[publish @vmw/ng-live-docs]` to publish @vmw/ng-live-docs@next
+-   `[publish @vmw/plain-js-live-docs@latest]` to publish @vmw/plain-js-live-docs@latest
+-   `[publish @vmw/ng-live-docs@latest]` to publish @vmw/ng-live-docs@latest
+
+And modify the corresponding package.json files:
+
+-   [projects/ng-live-docs/package.json](./projects/ng-live-docs/package.json)
+-   [projects/plain-js-live-docs/package.json](./projects/plain-live-docs/package.json).
+
+Note that `@latest` releases are only to be created when we release a version of VCD. Most releases, except for the
+final release that is used by a release of VCD, should be `@next`
 
 ## To run dev server with simple examples
 
@@ -60,4 +68,4 @@ a theme to be used.
 
 # How to use it
 
-For Angular based libraries, please look at 'How to use it' it section of [a relative link](./projects/ng-live-docs/README.md)
+For Angular based libraries, please look at 'How to use it' it section of [NG LiveDocs](./projects/ng-live-docs/README.md)


### PR DESCRIPTION
## Problem Description

Checking the actual package.json version was causing problems
when using versions such as `3.0.0-dev.1` because the action we used
wasn't able to tell that `3.0.0-dev.2` was higher
    
## New Behavior
We don't check versions anymore. Users are responsible for updating
package.json to a valid version and an error will occur if, for
 example, they add the magic string but forget to bump package.json.
    
The magic strings are described in the [Publishing section of our  README.md file](https://github.com/vmware/live-docs/pull/42/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48)

## Testing Done

Created multiple commits, each with the following modifications, which were removed for the PR:
* npm publish command was changed to an echo
* checks for master branch were removed

### Created different commits

* One commit did not have any of the magic strings
  * Made sure that the job to publish was completely ignored 
![image](https://user-images.githubusercontent.com/549331/153680882-a4fb7e6a-790a-4d1a-a974-9c7040bcf762.png)

* One commit containing `[publish @vmw/plain-js-live-docs]` and `[publish @vmw/ng-live-docs@latest]` 
  * Mad sure that both jobs ran
  * The `@vmw/plain-js-live-docs@next`  step did not run
  * The `@vmw/plain-js-live-docs@latest`  step did run
  * The `@vmw/ng-live-docs@next`  step did run
  * The `@vmw/ng-live-docs@latest`  step did not run

* One commit containing `[publish @vmw/plain-js-live-docs@latest]` and `[publish @vmw/ng-live-docs]` 
  * Mad sure that both jobs ran
  * The `@vmw/plain-js-live-docs@next`  step did run
  * The `@vmw/plain-js-live-docs@latest`  step did not run
  * The `@vmw/ng-live-docs@next`  step did not run
  * The `@vmw/ng-live-docs@latest`  step did  run