### PR TITLE
Publishing 0.0.14 - make ng-live-docs/index.js run on Windows

### DIFF
--- a/projects/ng-live-docs/CHANGELOG.md
+++ b/projects/ng-live-docs/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.0.14]
+
+### Fixed
+
+Make @vmw/ng-live-docs/index.js work on Windows
+
 ## [0.0.13]
 
 The first good version after problems with the pipeline. Version to be used for  

--- a/projects/ng-live-docs/package.json
+++ b/projects/ng-live-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/ng-live-docs",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "peerDependencies": {
     "@angular/common": "~11",
     "@angular/core": "~11",


### PR DESCRIPTION
[publish @vmw/ng-live-docs]

Signed-off-by: Juan Mendes <mendejuan@gmail.com>